### PR TITLE
Minor fixes to run some of your codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ cd ..
 wget http://nlp.cs.washington.edu/triviaqa/data/triviaqa-unfiltered.tar.gz
 tar xf triviaqa-unfiltered.tar.gz
 rm triviaqa-unfiltered.tar.gz
+cd ..
 ```
 
 First tokenize evidence documents by

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Next, retrieve top-n paragraphs based on TF-IDF to construct the train and dev s
 ```shell
 python -m triviaqa.ablate_triviaqa_wiki --n_processes 8 --n_para_train 12 --n_para_dev 14 --n_para_test 14 --do_train --do_dev --do_test
 python -m triviaqa.ablate_triviaqa_unfiltered --n_processes 8 --n_para_train 12 --n_para_dev 14 --n_para_test 14 --do_train --do_dev --do_test
+cp data/triviaqa/qa/wikipedia-dev.json data/triviaqa/wiki/
+cp data/triviaqa-unfiltered/unfiltered-web-dev.json data/triviaqa/unfiltered/
 ```
 
 ### Wikipedia Domain
@@ -171,7 +173,7 @@ python -m bert.run_triviaqa_wiki_full_e2e  \
   --do_train \
   --do_dev \
   --data_dir $DATA_DIR \
-  --dev_file unfiltered-web-dev.json
+  --dev_file unfiltered-web-dev.json \
   --train_batch_size 32 \
   --learning_rate 3e-5 \
   --num_train_epochs 2.0 \

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ or testing in the unfiltered setting requires the unfiltered data to be
 download to `data/triviaqa-unfiltered`.
 ```bash
 mkdir -p data/triviaqa
-cd /data/triviaqa
+cd data/triviaqa
 wget http://nlp.cs.washington.edu/triviaqa/data/triviaqa-rc.tar.gz
 tar xf triviaqa-rc.tar.gz
 rm triviaqa-rc.tar.gz

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The raw TriviaQA data is expected to be unzipped in `data/triviaqa`. Training
 or testing in the unfiltered setting requires the unfiltered data to be 
 download to `data/triviaqa-unfiltered`.
 ```bash
-mkdir -p /data/triviaqa
+mkdir -p data/triviaqa
 cd /data/triviaqa
 wget http://nlp.cs.washington.edu/triviaqa/data/triviaqa-rc.tar.gz
 tar xf triviaqa-rc.tar.gz

--- a/README.md
+++ b/README.md
@@ -92,17 +92,17 @@ Reader, type: test_open, step: 19332, em: 40.123, f1: 48.358
 
 ## TriviaQA
 ### Data Preprocessing
-The raw TriviaQA data is expected to be unzipped in `~/data/triviaqa`. Training
+The raw TriviaQA data is expected to be unzipped in `data/triviaqa`. Training
 or testing in the unfiltered setting requires the unfiltered data to be 
-download to `~/data/triviaqa-unfiltered`.
+download to `data/triviaqa-unfiltered`.
 ```bash
-mkdir -p ~/data/triviaqa
-cd ~/data/triviaqa
+mkdir -p /data/triviaqa
+cd /data/triviaqa
 wget http://nlp.cs.washington.edu/triviaqa/data/triviaqa-rc.tar.gz
 tar xf triviaqa-rc.tar.gz
 rm triviaqa-rc.tar.gz
 
-cd ~/data
+cd ..
 wget http://nlp.cs.washington.edu/triviaqa/data/triviaqa-unfiltered.tar.gz
 tar xf triviaqa-unfiltered.tar.gz
 rm triviaqa-unfiltered.tar.gz
@@ -170,6 +170,7 @@ python -m bert.run_triviaqa_wiki_full_e2e  \
   --do_train \
   --do_dev \
   --data_dir $DATA_DIR \
+  --dev_file unfiltered-web-dev.json
   --train_batch_size 32 \
   --learning_rate 3e-5 \
   --num_train_epochs 2.0 \

--- a/triviaqa/build_span_corpus.py
+++ b/triviaqa/build_span_corpus.py
@@ -5,15 +5,14 @@ import unicodedata
 from itertools import islice
 from typing import List, Optional, Dict
 from os import mkdir
-from os.path import join, exists, expanduser
+from os.path import join, exists
 import bert.tokenization as tokenization
 from triviaqa.configurable import Configurable
 from triviaqa.read_data import iter_trivia_question, TriviaQaQuestion
 from triviaqa.evidence_corpus import TriviaQaEvidenceCorpusTxt
 from triviaqa.answer_detection import compute_answer_spans_par, FastNormalizedAnswerDetector
 
-TRIVIA_QA = join(expanduser("~"), "data", "triviaqa")
-TRIVIA_QA_UNFILTERED = join(expanduser("~"), "data", "triviaqa-unfiltered")
+TRIVIA_QA = join("data", "triviaqa")
 
 
 def build_dataset(name: str, tokenizer, train_files: Dict[str, str],

--- a/triviaqa/build_span_corpus.py
+++ b/triviaqa/build_span_corpus.py
@@ -123,58 +123,58 @@ class TriviaQaSampleUnfilteredDataset(TriviaQaSpanCorpus):
 def build_wiki_corpus(n_processes):
     build_dataset("wiki", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "qa", "verified-wikipedia-dev.json"),
-                      dev=join(TRIVIA_QA, "qa", "wikipedia-dev.json"),
-                      train=join(TRIVIA_QA, "qa", "wikipedia-train.json"),
-                      test=join(TRIVIA_QA, "qa", "wikipedia-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "wiki", "verified-wikipedia-dev.json"),
+                      dev=join(TRIVIA_QA, "wiki", "wikipedia-dev.json"),
+                      train=join(TRIVIA_QA, "wiki", "wikipedia-train.json"),
+                      test=join(TRIVIA_QA, "wiki", "wikipedia-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes)
 
 def build_web_corpus(n_processes):
     build_dataset("web", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "qa", "verified-web-dev.json"),
-                      dev=join(TRIVIA_QA, "qa", "web-dev.json"),
-                      train=join(TRIVIA_QA, "qa", "web-train.json"),
-                      test=join(TRIVIA_QA, "qa", "web-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "web", "verified-web-dev.json"),
+                      dev=join(TRIVIA_QA, "web", "web-dev.json"),
+                      train=join(TRIVIA_QA, "web", "web-train.json"),
+                      test=join(TRIVIA_QA, "web", "web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes)
 
 def build_unfiltered_corpus(n_processes):
     build_dataset("unfiltered", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      dev=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-dev.json"),
-                      train=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-train.json"),
-                      test=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-test-without-answers.json")
+                      dev=join(TRIVIA_QA, "unfiltered", "unfiltered-web-dev.json"),
+                      train=join(TRIVIA_QA, "unfiltered", "unfiltered-web-train.json"),
+                      test=join(TRIVIA_QA, "unfiltered", "unfiltered-web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes)
 
 def build_wiki_sample_corpus(n_processes):
     build_dataset("wiki-sample", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "qa", "verified-wikipedia-dev.json"),
-                      dev=join(TRIVIA_QA, "qa", "wikipedia-dev.json"),
-                      train=join(TRIVIA_QA, "qa", "wikipedia-train.json"),
-                      test=join(TRIVIA_QA, "qa", "wikipedia-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "wiki-sample", "verified-wikipedia-dev.json"),
+                      dev=join(TRIVIA_QA, "wiki-sample", "wikipedia-dev.json"),
+                      train=join(TRIVIA_QA, "wiki-sample", "wikipedia-train.json"),
+                      test=join(TRIVIA_QA, "wiki-sample", "wikipedia-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes, sample=20)
 
 def build_web_sample_corpus(n_processes):
     build_dataset("web-sample", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "qa", "verified-web-dev.json"),
-                      dev=join(TRIVIA_QA, "qa", "web-dev.json"),
-                      train=join(TRIVIA_QA, "qa", "web-train.json"),
-                      test=join(TRIVIA_QA, "qa", "web-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "web-sample", "verified-web-dev.json"),
+                      dev=join(TRIVIA_QA, "web-sample", "web-dev.json"),
+                      train=join(TRIVIA_QA, "web-sample", "web-train.json"),
+                      test=join(TRIVIA_QA, "web-sample", "web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes, sample=20)
 
 def build_unfiltered_sample_corpus(n_processes):
     build_dataset("unfiltered-sample", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      dev=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-dev.json"),
-                      train=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-train.json"),
-                      test=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-test-without-answers.json")
+                      dev=join(TRIVIA_QA, "unfiltered-sample", "unfiltered-web-dev.json"),
+                      train=join(TRIVIA_QA, "unfiltered-sample", "unfiltered-web-train.json"),
+                      test=join(TRIVIA_QA, "unfiltered-sample", "unfiltered-web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes, sample=20)
 

--- a/triviaqa/build_span_corpus.py
+++ b/triviaqa/build_span_corpus.py
@@ -13,6 +13,7 @@ from triviaqa.evidence_corpus import TriviaQaEvidenceCorpusTxt
 from triviaqa.answer_detection import compute_answer_spans_par, FastNormalizedAnswerDetector
 
 TRIVIA_QA = join("data", "triviaqa")
+TRIVIA_QA_UNFILTERED = join("data", "triviaqa-unfiltered")
 
 
 def build_dataset(name: str, tokenizer, train_files: Dict[str, str],
@@ -23,7 +24,6 @@ def build_dataset(name: str, tokenizer, train_files: Dict[str, str],
         mkdir(out_dir)
 
     file_map = {}  # maps document_id -> filename
-
     for name, filename in train_files.items():
         print("Loading %s questions" % name)
         if sample is None:
@@ -123,58 +123,58 @@ class TriviaQaSampleUnfilteredDataset(TriviaQaSpanCorpus):
 def build_wiki_corpus(n_processes):
     build_dataset("wiki", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "wiki", "verified-wikipedia-dev.json"),
-                      dev=join(TRIVIA_QA, "wiki", "wikipedia-dev.json"),
-                      train=join(TRIVIA_QA, "wiki", "wikipedia-train.json"),
-                      test=join(TRIVIA_QA, "wiki", "wikipedia-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "qa", "verified-wikipedia-dev.json"),
+                      dev=join(TRIVIA_QA, "qa", "wikipedia-dev.json"),
+                      train=join(TRIVIA_QA, "qa", "wikipedia-train.json"),
+                      test=join(TRIVIA_QA, "qa", "wikipedia-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes)
 
 def build_web_corpus(n_processes):
     build_dataset("web", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "web", "verified-web-dev.json"),
-                      dev=join(TRIVIA_QA, "web", "web-dev.json"),
-                      train=join(TRIVIA_QA, "web", "web-train.json"),
-                      test=join(TRIVIA_QA, "web", "web-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "qa", "verified-web-dev.json"),
+                      dev=join(TRIVIA_QA, "qa", "web-dev.json"),
+                      train=join(TRIVIA_QA, "qa", "web-train.json"),
+                      test=join(TRIVIA_QA, "qa", "web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes)
 
 def build_unfiltered_corpus(n_processes):
     build_dataset("unfiltered", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      dev=join(TRIVIA_QA, "unfiltered", "unfiltered-web-dev.json"),
-                      train=join(TRIVIA_QA, "unfiltered", "unfiltered-web-train.json"),
-                      test=join(TRIVIA_QA, "unfiltered", "unfiltered-web-test-without-answers.json")
+                      dev=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-dev.json"),
+                      train=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-train.json"),
+                      test=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes)
 
 def build_wiki_sample_corpus(n_processes):
     build_dataset("wiki-sample", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "wiki-sample", "verified-wikipedia-dev.json"),
-                      dev=join(TRIVIA_QA, "wiki-sample", "wikipedia-dev.json"),
-                      train=join(TRIVIA_QA, "wiki-sample", "wikipedia-train.json"),
-                      test=join(TRIVIA_QA, "wiki-sample", "wikipedia-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "qa", "verified-wikipedia-dev.json"),
+                      dev=join(TRIVIA_QA, "qa", "wikipedia-dev.json"),
+                      train=join(TRIVIA_QA, "qa", "wikipedia-train.json"),
+                      test=join(TRIVIA_QA, "qa", "wikipedia-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes, sample=20)
 
 def build_web_sample_corpus(n_processes):
     build_dataset("web-sample", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      verified=join(TRIVIA_QA, "web-sample", "verified-web-dev.json"),
-                      dev=join(TRIVIA_QA, "web-sample", "web-dev.json"),
-                      train=join(TRIVIA_QA, "web-sample", "web-train.json"),
-                      test=join(TRIVIA_QA, "web-sample", "web-test-without-answers.json")
+                      verified=join(TRIVIA_QA, "qa", "verified-web-dev.json"),
+                      dev=join(TRIVIA_QA, "qa", "web-dev.json"),
+                      train=join(TRIVIA_QA, "qa", "web-train.json"),
+                      test=join(TRIVIA_QA, "qa", "web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes, sample=20)
 
 def build_unfiltered_sample_corpus(n_processes):
     build_dataset("unfiltered-sample", tokenization.BasicTokenizer(do_lower_case=True),
                   dict(
-                      dev=join(TRIVIA_QA, "unfiltered-sample", "unfiltered-web-dev.json"),
-                      train=join(TRIVIA_QA, "unfiltered-sample", "unfiltered-web-train.json"),
-                      test=join(TRIVIA_QA, "unfiltered-sample", "unfiltered-web-test-without-answers.json")
+                      dev=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-dev.json"),
+                      train=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-train.json"),
+                      test=join(TRIVIA_QA_UNFILTERED, "unfiltered-web-test-without-answers.json")
                   ),
                   FastNormalizedAnswerDetector(), n_processes, sample=20)
 

--- a/triviaqa/evidence_corpus.py
+++ b/triviaqa/evidence_corpus.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 from os import walk, mkdir, makedirs
-from os.path import relpath, join, exists, expanduser
+from os.path import relpath, join, exists
 from typing import Set
 from tqdm import tqdm
 from typing import List
@@ -10,7 +10,7 @@ import bert.tokenization as tokenization
 from triviaqa.utils import split, flatten_iterable, group
 from triviaqa.read_data import normalize_wiki_filename
 
-TRIVIA_QA = join(expanduser("~"), "data", "triviaqa")
+TRIVIA_QA = join("data", "triviaqa")
 
 class MergeParagraphs(object):
     def __init__(self, max_tokens: int):


### PR DESCRIPTION
Hello,

First of all, thank you for sharing your code!

I tried to reproduce results in your paper, and found there are two different "data" folders (one at user home, one at the same level of src folder), which caused some errors like FileNotFoundError

With my minor fixes (including README.md) and the following scripts, there will be only one data folder (at the same level of src folder), and we can complete tasks for SQuAD-doc, TriviaQA-wiki, and TriviaQA-open.

```
# Python 3.6 and torch==1.1.0 were used
export DATA_DIR=data/squad
export BERT_DIR=bert-base-uncased

python -m bert.run_squad_document_full_e2e \
  --vocab_file $BERT_DIR/vocab.txt \
  --bert_config_file $BERT_DIR/bert_config.json \
  --init_checkpoint $BERT_DIR/pytorch_model.bin \
  --do_train \
  --do_predict \
  --data_dir $DATA_DIR \
  --train_file train-v1.1.json \
  --predict_file dev-v1.1.json \
  --train_batch_size 16 \
  --learning_rate 3e-5 \
  --num_train_epochs 2.0 \
  --output_dir out/squad_doc/01

python -m bert.run_squad_document_full_e2e \
  --vocab_file $BERT_DIR/vocab.txt \
  --bert_config_file $BERT_DIR/bert_config.json \
  --do_predict_open \
  --data_dir $DATA_DIR \
  --output_dir out/squad_doc/01

python -m triviaqa.evidence_corpus --n_processes 8 --max_tokens 200
python -m triviaqa.build_span_corpus wiki --n_processes 8
python -m triviaqa.build_span_corpus unfiltered --n_processes 8

python -m triviaqa.ablate_triviaqa_wiki --n_processes 8 --n_para_train 12 --n_para_dev 14 --n_para_test 14 --do_train --do_dev --do_test
python -m triviaqa.ablate_triviaqa_unfiltered --n_processes 8 --n_para_train 12 --n_para_dev 14 --n_para_test 14 --do_train --do_dev --do_test
cp data/triviaqa/qa/wikipedia-dev.json data/triviaqa/wiki/
cp data/triviaqa-unfiltered/unfiltered-web-dev.json data/triviaqa/unfiltered/

export DATA_DIR=data/triviaqa/wiki
export BERT_DIR=bert-base-uncased

python -m bert.run_triviaqa_wiki_full_e2e  \
  --vocab_file $BERT_DIR/vocab.txt \
  --bert_config_file $BERT_DIR/bert_config.json \
  --init_checkpoint $BERT_DIR/pytorch_model.bin \
  --do_train \
  --do_dev \
  --data_dir $DATA_DIR \
  --train_batch_size 16 \
  --learning_rate 3e-5 \
  --num_train_epochs 2.0 \
  --output_dir out/triviaqa_wiki/01

export DATA_DIR=data/triviaqa/unfiltered
export BERT_DIR=bert-base-uncased

python -m bert.run_triviaqa_wiki_full_e2e  \
  --vocab_file $BERT_DIR/vocab.txt \
  --bert_config_file $BERT_DIR/bert_config.json \
  --init_checkpoint $BERT_DIR/pytorch_model.bin \
  --do_train \
  --do_dev \
  --data_dir $DATA_DIR \
  --dev_file unfiltered-web-dev.json \
  --train_batch_size 16 \
  --learning_rate 3e-5 \
  --num_train_epochs 2.0 \
  --output_dir out/triviaqa_unfiltered/01
```

Note: At first I tried to set 32 at train_batch_size for both models as suggested, but faced CUDA out of memory error even with 4 GPUs (each of them has 16GB video memory), so used 16 as train_batch_size

Regardless of my minor fixes, I faced a different error for SQuAD-open, but couldn't fix it shortly.
I will submit issues with some additional questions, and put the links here later.

Thank you!